### PR TITLE
Take screenshots

### DIFF
--- a/src/Editor.cs
+++ b/src/Editor.cs
@@ -74,6 +74,13 @@ namespace linerider
                 Invalidate();
             }
         }
+        public float BaseZoom //Zoom without the multiplier
+        {
+            get
+            {
+                return _zoom;
+            }
+        }
         public Song Song
         {
             get

--- a/src/GameCanvas.cs
+++ b/src/GameCanvas.cs
@@ -318,6 +318,10 @@ namespace linerider
                 ShowffmpegMissing();
             }
         }
+        public void ShowScreenCaptureWindow()
+        {
+            ShowDialog(new ScreenshotWindow(this, game.Track, game));
+        }
         public void ShowGameMenuWindow()
         {
             ShowDialog(new GameMenuWindow(this, game.Track));

--- a/src/IO/TrackRecorder.cs
+++ b/src/IO/TrackRecorder.cs
@@ -92,8 +92,10 @@ namespace linerider.IO
             var oldZoomMultiplier = Settings.ZoomMultiplier;
             var oldHitTest = Settings.Editor.HitTest;
 
-            Settings.ZoomMultiplier *= game.ClientSize.Width > game.ClientSize.Height * 16 / 9 ? (float)Settings.ScreenshotWidth / (float)game.ClientSize.Width : (float)Settings.ScreenshotHeight / (float)game.ClientSize.Height;
+            if(Settings.Recording.ResIndZoom)
+                Settings.ZoomMultiplier *= game.ClientSize.Width > game.ClientSize.Height * 16 / 9 ? (float)Settings.ScreenshotWidth / (float)game.ClientSize.Width : (float)Settings.ScreenshotHeight / (float)game.ClientSize.Height;
             Settings.Editor.HitTest = Settings.Recording.ShowHitTest;
+            game.Canvas.Scale = Settings.ZoomMultiplier / oldZoomMultiplier; //Divide just in case anyone modifies the zoom multiplier to not be 1
 
             using (var trk = game.Track.CreateTrackReader())
             {
@@ -142,6 +144,7 @@ namespace linerider.IO
                 Settings.Editor.HitTest = oldHitTest;
 
                 game.Canvas.SetSize(game.RenderSize.Width, game.RenderSize.Height);
+                game.Canvas.Scale = 1.0f;
                 _screenshotbuffer = null;
             }
         }
@@ -156,8 +159,10 @@ namespace linerider.IO
             var oldHitTest = Settings.Editor.HitTest;
             var invalid = false;
 
-            Settings.ZoomMultiplier *= game.ClientSize.Width > game.ClientSize.Height * 16 / 9 ? (float)Settings.RecordingWidth / (float)game.ClientSize.Width : (float)Settings.RecordingHeight / (float)game.ClientSize.Height;
+            if(Settings.Recording.ResIndZoom)
+                Settings.ZoomMultiplier *= game.ClientSize.Width > game.ClientSize.Height * 16 / 9 ? (float)Settings.RecordingWidth / (float)game.ClientSize.Width : (float)Settings.RecordingHeight / (float)game.ClientSize.Height;
             Settings.Editor.HitTest = Settings.Recording.ShowHitTest;
+            game.Canvas.Scale = Settings.ZoomMultiplier /oldZoomMultiplier; //Divide just in case anyone modifies the zoom multiplier to not be 1
 
             using (var trk = game.Track.CreateTrackReader())
             {
@@ -418,6 +423,7 @@ namespace linerider.IO
                 Settings.Editor.HitTest = oldHitTest;
 
                 game.Canvas.SetSize(game.RenderSize.Width, game.RenderSize.Height);
+                game.Canvas.Scale = 1.0f;
                 _screenshotbuffer = null;
             }
         }

--- a/src/IO/TrackRecorder.cs
+++ b/src/IO/TrackRecorder.cs
@@ -125,7 +125,6 @@ namespace linerider.IO
 
                 var recmodesave = Settings.Local.RecordingMode;
                 Settings.Local.RecordingMode = true;
-                //game.Track.StartIgnoreFlag(); TODO remove this line?
                 game.Render();
                 var screenshotframe = GrabScreenshot(game, frontbuffer, true);
                 SaveScreenshot(game.RenderSize.Width, game.RenderSize.Height, screenshotframe, filename);

--- a/src/IO/TrackRecorder.cs
+++ b/src/IO/TrackRecorder.cs
@@ -35,6 +35,8 @@ using linerider.IO.ffmpeg;
 using Key = OpenTK.Input.Key;
 using PixelFormat = System.Drawing.Imaging.PixelFormat;
 using System.Runtime.InteropServices;
+using linerider.Utils;
+
 namespace linerider.IO
 {
     internal static class TrackRecorder
@@ -113,7 +115,14 @@ namespace linerider.IO
                 _screenshotbuffer = new byte[game.RenderSize.Width * game.RenderSize.Height * 3];// 3 bytes per pixel
                 game.Title = Program.WindowTitle + " [Capturing Screenshot]";
                 game.ProcessEvents();
-                var filename = Program.UserDirectory + game.Track.Name + ".png";
+                
+                string filename;
+
+                if(game.Track.Name == Constants.DefaultTrackName)
+                    filename = Program.UserDirectory + "Untitled Track" + ".png";
+                else
+                    filename = Program.UserDirectory + game.Track.Name + ".png";
+
                 var recmodesave = Settings.Local.RecordingMode;
                 Settings.Local.RecordingMode = true;
                 //game.Track.StartIgnoreFlag(); TODO remove this line?

--- a/src/MainWindow.cs
+++ b/src/MainWindow.cs
@@ -77,6 +77,10 @@ namespace linerider
                 {
                     return new Size(Settings.RecordingWidth, Settings.RecordingHeight);
                 }
+                else if (TrackRecorder.RecordingScreenshot)
+                {
+                    return new Size(Settings.ScreenshotWidth, Settings.ScreenshotHeight);
+                }
                 return ClientSize;
             }
             set

--- a/src/UI/Dialogs/ExportWindow.cs
+++ b/src/UI/Dialogs/ExportWindow.cs
@@ -144,7 +144,7 @@ namespace linerider.UI
                 Settings.Recording.EnableColorTriggers);
             var resIndZoom = AddPropertyCheckbox(
                 table,
-                "Resolution-Independent Zoom",
+                "Res-Independent Zoom",
                 Settings.Recording.ResIndZoom);
             proptree.ExpandAll();
             Button Cancel = new Button(bottomrow)

--- a/src/UI/Dialogs/ScreenshotWindow.cs
+++ b/src/UI/Dialogs/ScreenshotWindow.cs
@@ -165,7 +165,7 @@ namespace linerider.UI
                Settings.Editor.HitTest);
             var resIndZoom = AddPropertyCheckbox(
                 table,
-                "Resolution-Independent Zoom",
+                "Res-Independent Zoom",
                 Settings.Recording.ResIndZoom);
             proptree.ExpandAll();
             Button Cancel = new Button(bottomrow)

--- a/src/UI/Dialogs/ScreenshotWindow.cs
+++ b/src/UI/Dialogs/ScreenshotWindow.cs
@@ -192,17 +192,6 @@ namespace linerider.UI
                     Settings.Recording.ResIndZoom = resIndZoom.IsChecked;
                     Settings.Recording.ShowHitTest = hitTest.IsChecked;
 
-                    /*try
-                    {
-                        var size = resolutions[qualitycb.SelectedItem.Text];
-                        Settings.ScreenshotWidth = size.Width;
-                        Settings.ScreenshotHeight = size.Height;
-                    }
-                    catch (KeyNotFoundException)
-                    {
-                        throw new Exception("Invalid resolution: " + qualitycb.SelectedItem.Text);
-                    }*/
-
                     Settings.Save();
                     Record();
                 };
@@ -223,11 +212,6 @@ namespace linerider.UI
         }
         private void Record()
         {
-            /*IO.TrackRecorder.RecordTrack(
-                _game,
-                Settings.RecordSmooth,
-                Settings.RecordMusic && !Settings.MuteAudio);*/
-
             IO.TrackRecorder.RecordScreenshot(_game);
         }
     }

--- a/src/UI/Widgets/RightInfoBar.cs
+++ b/src/UI/Widgets/RightInfoBar.cs
@@ -47,7 +47,7 @@ namespace linerider.UI
             _fpslabel.IsHidden = rec && !Settings.Recording.ShowFps;
             _riderspeedlabel.IsHidden = rec && !Settings.Recording.ShowPpf;
             _playbackratelabel.IsHidden = rec || _editor.Scheduler.UpdatesPerSecond == 40;
-            _usercamerasprite.IsHidden = !_editor.UseUserZoom && _editor.Zoom == _editor.Timeline.GetFrameZoom(_editor.Offset);
+            _usercamerasprite.IsHidden = !_editor.UseUserZoom && _editor.Zoom == _editor.Timeline.GetFrameZoom(_editor.Offset) * Settings.ZoomMultiplier;
             _iconpanel.IsHidden = _usercamerasprite.IsHidden;
         }
         private void Setup()

--- a/src/UI/Widgets/RightInfoBar.cs
+++ b/src/UI/Widgets/RightInfoBar.cs
@@ -47,7 +47,7 @@ namespace linerider.UI
             _fpslabel.IsHidden = rec && !Settings.Recording.ShowFps;
             _riderspeedlabel.IsHidden = rec && !Settings.Recording.ShowPpf;
             _playbackratelabel.IsHidden = rec || _editor.Scheduler.UpdatesPerSecond == 40;
-            _usercamerasprite.IsHidden = !_editor.UseUserZoom && _editor.Zoom == _editor.Timeline.GetFrameZoom(_editor.Offset) * Settings.ZoomMultiplier;
+            _usercamerasprite.IsHidden = !_editor.UseUserZoom && _editor.BaseZoom == _editor.Timeline.GetFrameZoom(_editor.Offset);
             _iconpanel.IsHidden = _usercamerasprite.IsHidden;
         }
         private void Setup()

--- a/src/UI/Widgets/Toolbar.cs
+++ b/src/UI/Widgets/Toolbar.cs
@@ -174,6 +174,7 @@ namespace linerider.UI
                 menu.AddItem("Track Properties").Clicked += (o2, e2) => _canvas.ShowTrackPropertiesDialog();
                 menu.AddItem("Triggers").Clicked += (o2, e2) => _canvas.ShowTriggerWindow();
                 menu.AddItem("Export Video").Clicked += (o2, e2) => _canvas.ShowExportVideoWindow();
+                menu.AddItem("Capture Screen").Clicked += (o2, e2) => _canvas.ShowScreenCaptureWindow();
                 var canvaspos = LocalPosToCanvas(new Point(_menu.X, _menu.Y));
                 menu.SetPosition(canvaspos.X, canvaspos.Y + 32);
                 menu.Show();

--- a/src/Utils/Settings.cs
+++ b/src/Utils/Settings.cs
@@ -45,6 +45,7 @@ namespace linerider
             public static bool ShowTools = false;
             public static bool ShowFps = true;
             public static bool ShowPpf = true;
+            public static bool ShowHitTest = false;
             public static bool EnableColorTriggers = true;
             public static bool ResIndZoom = true; //Use resolution-independent zoom based on window size when recording
         }
@@ -109,6 +110,8 @@ namespace linerider
         public static bool RecordMusic;
         public static int RecordingWidth;
         public static int RecordingHeight;
+        public static int ScreenshotWidth;
+        public static int ScreenshotHeight;
         public static float ScrollSensitivity;
         public static int SettingsPane;
         public static bool MuteAudio;
@@ -244,6 +247,8 @@ namespace linerider
             RecordMusic = true;
             RecordingWidth = 1280;
             RecordingHeight = 720;
+            ScreenshotWidth = 1280;
+            ScreenshotHeight = 720;
             ScrollSensitivity = 1;
             SettingsPane = 0;
             MuteAudio = false;
@@ -508,6 +513,8 @@ namespace linerider
             LoadBool(GetSetting(lines, nameof(RecordMusic)), ref RecordMusic);
             LoadInt(GetSetting(lines, nameof(RecordingWidth)), ref RecordingWidth);
             LoadInt(GetSetting(lines, nameof(RecordingHeight)), ref RecordingHeight);
+            LoadInt(GetSetting(lines, nameof(ScreenshotWidth)), ref ScreenshotWidth);
+            LoadInt(GetSetting(lines, nameof(ScreenshotHeight)), ref ScreenshotHeight);
             LoadBool(GetSetting(lines, nameof(Editor.LifeLockNoFakie)), ref Editor.LifeLockNoFakie);
             LoadBool(GetSetting(lines, nameof(Editor.LifeLockNoOrange)), ref Editor.LifeLockNoOrange);
             LoadInt(GetSetting(lines, nameof(SettingsPane)), ref SettingsPane);
@@ -613,6 +620,8 @@ namespace linerider
             config += "\r\n" + MakeSetting(nameof(RecordMusic), RecordMusic.ToString(Program.Culture));
             config += "\r\n" + MakeSetting(nameof(RecordingWidth), RecordingWidth.ToString(Program.Culture));
             config += "\r\n" + MakeSetting(nameof(RecordingHeight), RecordingHeight.ToString(Program.Culture));
+            config += "\r\n" + MakeSetting(nameof(ScreenshotWidth), ScreenshotWidth.ToString(Program.Culture));
+            config += "\r\n" + MakeSetting(nameof(ScreenshotHeight), ScreenshotHeight.ToString(Program.Culture));
             config += "\r\n" + MakeSetting(nameof(ScrollSensitivity), ScrollSensitivity.ToString(Program.Culture));
             config += "\r\n" + MakeSetting(nameof(Editor.LifeLockNoFakie), Editor.LifeLockNoFakie.ToString(Program.Culture));
             config += "\r\n" + MakeSetting(nameof(Editor.LifeLockNoOrange), Editor.LifeLockNoOrange.ToString(Program.Culture));

--- a/src/linerider.csproj
+++ b/src/linerider.csproj
@@ -192,6 +192,7 @@
   </ItemGroup>
   <ItemGroup>
     <Compile Include="UI\Dialogs\ChangelogWindow.cs" />
+    <Compile Include="UI\Dialogs\ScreenshotWindow.cs" />
     <Compile Include="UI\Dialogs\GeneratorWindow.cs" />
     <Compile Include="UI\Dialogs\TriggerWindow.cs" />
     <Compile Include="UI\PlatformImpl.cs" />


### PR DESCRIPTION
Adds a feature which allows screenshots to be taken at arbitrary resolutions, instead of having to capture the window externally or extract a frame from a video. This branch also fixes a small bug where the reset camera button appears when encoding with resolution-independent zoom (or the zoom multiplier set to something other than 1), and abbreviates the name to res-independent zoom in both the screenshot & video recording windows to keep it from being too long to fit in the window. The now-redundant Recording1080p variable is also removed.