### PR TITLE
Timeline Trigger Window color fix

### DIFF
--- a/src/UI/Dialogs/TriggerWindow.cs
+++ b/src/UI/Dialogs/TriggerWindow.cs
@@ -325,9 +325,9 @@ namespace linerider.UI
                     }
                 }
             };
-            GwenHelper.CreateLabeledControl(_lineoptions, "Line Blue", _linered).Dock = Dock.Bottom;
+            GwenHelper.CreateLabeledControl(_lineoptions, "Line Blue", _lineblue).Dock = Dock.Bottom;
             GwenHelper.CreateLabeledControl(_lineoptions, "Line Green", _linegreen).Dock = Dock.Bottom;
-            GwenHelper.CreateLabeledControl(_lineoptions, "Line Red", _lineblue).Dock = Dock.Bottom;
+            GwenHelper.CreateLabeledControl(_lineoptions, "Line Red", _linered).Dock = Dock.Bottom;
         }
         private void SetupRight()
         {


### PR DESCRIPTION
The timeline trigger window had the red and blue values swapped for line color.  This fixes that error.