### PR TITLE
Add a recording option which starts the export on the current editor frame

### DIFF
--- a/src/UI/Dialogs/ExportWindow.cs
+++ b/src/UI/Dialogs/ExportWindow.cs
@@ -109,6 +109,10 @@ namespace linerider.UI
             
             table.Add("Quality", qualitycb);
 
+            var startOnCurrentFrameCheck = AddPropertyCheckbox(
+                table,
+                "Start on Current Frame",
+                false);
             var smoothcheck = AddPropertyCheckbox(
                 table,
                 "Smooth Playback",
@@ -175,6 +179,7 @@ namespace linerider.UI
                     Settings.Recording.EnableColorTriggers = colorTriggers.IsChecked;
                     Settings.Recording.ResIndZoom = resIndZoom.IsChecked;
                     Settings.Recording.ShowHitTest = hitTest.IsChecked;
+                    Settings.currentFrame = startOnCurrentFrameCheck.IsChecked;
 
                     Settings.RecordSmooth = smoothcheck.IsChecked;
                     if (!music.IsDisabled)
@@ -216,7 +221,8 @@ namespace linerider.UI
             IO.TrackRecorder.RecordTrack(
                 _game,
                 Settings.RecordSmooth,
-                Settings.RecordMusic && !Settings.MuteAudio);
+                Settings.RecordMusic && !Settings.MuteAudio,
+                Settings.currentFrame ? (Settings.RecordSmooth ? (int)(_game.Track.Offset * 1.5) : _game.Track.Offset) : 0);
         }
     }
 }

--- a/src/Utils/Settings.cs
+++ b/src/Utils/Settings.cs
@@ -167,6 +167,10 @@ namespace linerider
 
         //Malizma Addon Settings
         public static bool InvisibleRider;
+
+        // if true, recordings start on the frame that is currently being edited (_game.Track.offset from ExportWindow)
+        public static bool currentFrame;
+
         static Settings()
         {
             RestoreDefaultSettings();


### PR DESCRIPTION
This adds a checkbox to the export window that makes the recording start on the current frame in the editor, instead of frame 0.


![PRScreenshot](https://user-images.githubusercontent.com/91579431/135349252-531b0a5b-19ae-4d0a-85d4-83ef7a2284de.PNG)

